### PR TITLE
Add flexible GunDB connection and browsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,38 +1,71 @@
-import { useEffect, useRef, useState } from 'react'
 import './App.css'
-import DataElement from './com/GunElement'
+import { useEffect, useState } from 'react'
+import DataBrowser from './com/DataBrowser'
+import DataEditor from './com/DataEditor'
 import Help from './com/Help'
 import { GunProvider, useGun } from './api/gunContext'
+import { getNode } from 'api/gunHelpers'
 
+function AppBody({ peers, setPeers, rootPath, setRootPath }) {
+  const gun = useGun()
+
+  const [selection, setSelection] = useState(null)
+  const [selectedData, setSelectedData] = useState(null)
+  const [showHelp, setShowHelp] = useState(false)
+
+  useEffect(() => {
+    if (!gun || !selection) {
+      setSelectedData(null)
+      return
+    }
+
+    const node = getNode(gun, selection)
+    node.on(setSelectedData)
+    return () => node.off()
+  }, [gun, selection])
+
+  return (
+    <>
+      <h1>GunDB Cockpit</h1>
+
+      <input
+        placeholder="Gun peer URL"
+        value={peers}
+        onChange={(e) => setPeers(e.target.value)}
+        type="text"
+      />
+
+      <input
+        placeholder="Root Path"
+        onChange={(e) => setRootPath(e.target.value)}
+        type="text"
+        value={rootPath}
+      />
+
+      <DataBrowser path={rootPath} setSelection={setSelection} />
+      <DataEditor data={selectedData || {}} path={selection} basePath={rootPath} />
+
+      <button id="help-button" onClick={() => setShowHelp(!showHelp)}>
+        {showHelp ? 'X' : '?'}
+      </button>
+
+      {showHelp && <Help />}
+    </>
+  )
+}
 
 export default function App() {
-  const gun = useGun()
-  
+  const [peers, setPeers] = useState('')
   const [rootPath, setRootPath] = useState('data')
-  const [showHelp, setShowHelp] = useState(false)
-  
-  
-  return <>
-    <h1>GunDB Cockpit</h1>
-    
-    <input autoFocus
-      placeholder="Root Path"
-      onChange={(e) => setRootPath(e.target.value)}
-      type="text"
-      value={rootPath}
-    />
-    
-    
-    <GunProvider>
-      <DataElement node={gun.get(rootPath)} name={rootPath} />
+
+  return (
+    <GunProvider peers={peers ? peers.split(',') : []}>
+      <AppBody
+        peers={peers}
+        setPeers={setPeers}
+        rootPath={rootPath}
+        setRootPath={setRootPath}
+      />
     </GunProvider>
-
-    <button id="help-button"
-      onClick={() => setShowHelp(!showHelp)}
-    >
-      {showHelp ? 'X' : '?'}
-    </button>
-
-    {showHelp && <Help />}
-  </>
+  )
 }

--- a/src/api/gunContext.jsx
+++ b/src/api/gunContext.jsx
@@ -6,13 +6,12 @@ import Gun from 'gun'
 const GunContext = createContext(null)
 
 
-export const GunProvider = ({ children, peers=[] }) => {
+export const GunProvider = ({ children, peers = [] }) => {
   const gun = useMemo(() => {
-    window.gun = Gun({
-      peers: peers,
-    })
+    const options = peers.length ? { peers } : {}
+    window.gun = Gun(options)
     return window.gun
-  }, [])
+  }, [peers])
   
   
   return (

--- a/src/api/gunHelpers.js
+++ b/src/api/gunHelpers.js
@@ -1,0 +1,8 @@
+export function getNode(gun, path) {
+  if (!gun) return null;
+  if (!path) return gun;
+  if (path.includes('/') && !path.includes('#')) {
+    return path.split('/').reduce((node, part) => node.get(part), gun);
+  }
+  return gun.get(path);
+}

--- a/src/com/DataBrowser.jsx
+++ b/src/com/DataBrowser.jsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import { useGun } from 'api/GunContext'
+import { getNode } from 'api/gunHelpers'
 
-export default function DataBrowser({setSelection}) {
+export default function DataBrowser({ setSelection, path = 'data' }) {
   const gun = useGun()
   const [data, setData] = useState({})
 
   useEffect(() => {
     if (!gun) return
     
-    const nodeRef = gun.get('myData')
+    const nodeRef = getNode(gun, path)
     nodeRef.on((nodeData) => {
       setData(nodeData)
     })
@@ -16,14 +17,15 @@ export default function DataBrowser({setSelection}) {
     return () => {
       nodeRef.off()
     }
-  }, [gun])
+  }, [gun, path])
 
   const handleSelect = (key, value) => {
-    const path = value && typeof value === 'object' && '#' in value
-      ? value['#']
-      : `myData/${key}`
-    
-    setSelection(path)
+    const nextPath =
+      value && typeof value === 'object' && '#' in value
+        ? value['#']
+        : `${path}/${key}`
+
+    setSelection(nextPath)
   }
 
   const renderData = () => {

--- a/src/com/DataEditor.jsx
+++ b/src/com/DataEditor.jsx
@@ -1,22 +1,24 @@
 import React, { useEffect, useState } from 'react'
 import { useGun } from 'api/GunContext'
+import { getNode } from 'api/gunHelpers'
 import JSONItem from './JSONItem'
 
 
-export default function DataEditor({data, path}) {
-  const gun = useGun();
-  const [keyName, setKeyName] = useState('');
-  const [value, setValue] = useState({});
+export default function DataEditor({ data, path, basePath = 'data' }) {
+  const gun = useGun()
+  const [keyName, setKeyName] = useState('')
+  const [value, setValue] = useState({})
   
   const handleSave = (e) => {
-    e.preventDefault();
-    if (!keyName || !value) return;
-    
-    // Put merges the data into the node
-    gun.get('myData').put({ [keyName]: value });
-    
-    // Clear out the fields
-    setKeyName('');
+    e.preventDefault()
+    const target = path ? getNode(gun, path) : getNode(gun, basePath)
+    if (path) {
+      target.put(value)
+    } else {
+      if (!keyName || value === undefined) return
+      target.put({ [keyName]: value })
+      setKeyName('')
+    }
     setValue('')
   }
   
@@ -52,7 +54,7 @@ export default function DataEditor({data, path}) {
             setData={newValue => setValue(newValue)}
           />
         </div>
-        <button disabled={!keyName || !value} type="submit">Save to Gun</button>
+        <button disabled={!path && (!keyName || !value)} type="submit">Save to Gun</button>
       </form>
       
       <pre>{JSON.stringify(value, null, 2)}</pre>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
-import { GunProvider } from 'api/gunContext'
 
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <GunProvider>
-      <App />
-    </GunProvider>
+    <App />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- rework Gun context so peer config is reactive
- add helper to traverse Gun paths
- update DataBrowser and DataEditor for generic paths
- overhaul App to accept peer URL and root path
- simplify main entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*